### PR TITLE
Add armhf docker file

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,11 @@
+FROM armhf/alpine:latest
+
+RUN apk --update add bash openssl
+
+WORKDIR /certs
+
+COPY generate-certs /usr/local/bin/generate-certs
+
+CMD /usr/local/bin/generate-certs
+
+VOLUME /certs


### PR DESCRIPTION
This uses `armhf/alpine:latest` a common distro for Pi docker image
ports.