### PR TITLE
Fix subjectAltNames not being added to generated certificate

### DIFF
--- a/generate-certs
+++ b/generate-certs
@@ -61,14 +61,14 @@ cat > ${SSL_CONFIG} <<EOM
 req_extensions = v3_req
 distinguished_name = req_distinguished_name
 [req_distinguished_name]
-[ v3_req ]
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage = clientAuth, serverAuth
 [ v3_ca ]
 basicConstraints = critical,CA:TRUE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, serverAuth
 EOM
 
 if [[ -n ${SSL_DNS} || -n ${SSL_IP} ]]; then


### PR DESCRIPTION
subjectAltName = @alt_names was added to [v3_ca], not [v3_req] as it should.
This prevented "X509v3 Subject Alternative Name" from being added to generated certificate.
Reordering fields in generated openssl.conf fixes the issue.