### PR TITLE
Fix armv7 exec format error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /certs
 
 COPY generate-certs /usr/local/bin/generate-certs
 
+RUN chmod +x /usr/local/bin/generate-certs
+
 CMD /usr/local/bin/generate-certs
 
 VOLUME /certs

--- a/generate-certs
+++ b/generate-certs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -z $SILENT ]]; then
 echo "----------------------------"


### PR DESCRIPTION
I encountered the following error when employing this image in an ARMv7 SOC:
```
standard_init_linux.go:211: exec user process caused "exec format error"
```

This PR fixes this issue.